### PR TITLE
Add addon status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# ToS-LKChat
+# ToS-LKChat [![Addon Status Unknown](https://cdn.rawgit.com/lubien/awesome-tos/master/badges/addon-unknown.svg)](https://github.com/lubien/awesome-tos#addons-badges)
 Tree of Savior Chat Addon


### PR DESCRIPTION
I'm proposing a badge pattern for Tree of Savior addons.
Using these badges, users can easily understand that the system they are using is approved / is safe / have a unknown status / is unsafe.
Read more at [Awesome ToS #addons-badges](https://github.com/lubien/awesome-tos#addons-badges).
Hope you like the idea.
